### PR TITLE
feat(facebook-auth): add facebook authentication to app

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -88,4 +88,8 @@
     <plugin name="cordova-plugin-contacts" spec="~2.3.1" />
     <engine name="android" spec="~6.2.3" />
     <allow-navigation href="http://192.168.153.117:8100" />
+    <plugin name="cordova-plugin-facebook4" spec="^1.9.1">
+        <variable name="APP_ID" value="1234567890" />
+        <variable name="APP_NAME" value="APP_NAME_HERE" />
+    </plugin>
 </widget>

--- a/config.xml
+++ b/config.xml
@@ -89,7 +89,7 @@
     <engine name="android" spec="~6.2.3" />
     <allow-navigation href="http://192.168.153.117:8100" />
     <plugin name="cordova-plugin-facebook4" spec="^1.9.1">
-        <variable name="APP_ID" value="1234567890" />
+        <variable name="APP_ID" value="125683201478357" />
         <variable name="APP_NAME" value="APP_NAME_HERE" />
     </plugin>
 </widget>

--- a/config.xml
+++ b/config.xml
@@ -90,6 +90,6 @@
     <allow-navigation href="http://192.168.153.117:8100" />
     <plugin name="cordova-plugin-facebook4" spec="^1.9.1">
         <variable name="APP_ID" value="125683201478357" />
-        <variable name="APP_NAME" value="APP_NAME_HERE" />
+        <variable name="APP_NAME" value="Bitf­i­n­d­r­test" />
     </plugin>
 </widget>

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
       "cordova-plugin-whitelist": {},
       "ionic-plugin-keyboard": {},
       "cordova-plugin-facebook4": {
-        "APP_ID": "1234567890",
+        "APP_ID": "125683201478357",
         "APP_NAME": "APP_NAME_HERE"
       }
     },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,11 @@
       "cordova-plugin-splashscreen": {},
       "cordova-plugin-statusbar": {},
       "cordova-plugin-whitelist": {},
-      "ionic-plugin-keyboard": {}
+      "ionic-plugin-keyboard": {},
+      "cordova-plugin-facebook4": {
+        "APP_ID": "1234567890",
+        "APP_NAME": "APP_NAME_HERE"
+      }
     },
     "platforms": [
       "android"
@@ -46,6 +50,7 @@
     "@ionic-native/clipboard": "4.3.2",
     "@ionic-native/contacts": "4.3.2",
     "@ionic-native/core": "4.3.2",
+    "@ionic-native/facebook": "4.3.2",
     "@ionic-native/splash-screen": "4.3.2",
     "@ionic-native/status-bar": "4.3.2",
     "@ionic/storage": "^2.0.1",
@@ -60,6 +65,7 @@
     "cordova-plugin-compat": "^1.2.0",
     "cordova-plugin-contacts": "^2.3.1",
     "cordova-plugin-device": "^1.1.4",
+    "cordova-plugin-facebook4": "^1.9.1",
     "cordova-plugin-splashscreen": "^4.0.3",
     "cordova-plugin-statusbar": "^2.2.2",
     "cordova-plugin-whitelist": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
       "ionic-plugin-keyboard": {},
       "cordova-plugin-facebook4": {
         "APP_ID": "125683201478357",
-        "APP_NAME": "APP_NAME_HERE"
+        "APP_NAME": "Bitf­i­n­d­r­test"
       }
     },
     "platforms": [

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -14,6 +14,7 @@ import { Clipboard } from '@ionic-native/clipboard';
 import { Contacts } from '@ionic-native/contacts';
 import { StatusBar } from '@ionic-native/status-bar';
 import { SplashScreen } from '@ionic-native/splash-screen';
+import { Facebook } from '@ionic-native/facebook';
 
 import { AngularFireModule } from 'angularfire2';
 import { AngularFireDatabaseModule } from 'angularfire2/database';
@@ -65,6 +66,7 @@ import { ROOT_REDUCER, META_REDUCERS, AuthFacade } from './../state';
     Clipboard,
     ToastProvider,
     Contacts,
+    Facebook,
     AngularFireDatabase,
     BitfindrDataProvider,
     ClipboardProvider,

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,11 +1,14 @@
 export const environment = {
     production: false,
+    facebook: {
+      scopes: ['email'],
+    },
     firebase: {
-        apiKey: 'AIzaSyBetWWMHjfRV1xd91BFHkJ0-aZcsil956o',
-        authDomain: 'bitpoint-app.firebaseapp.com',
-        databaseURL: 'https://bitpoint-app.firebaseio.com',
-        projectId: 'bitpoint-app',
-        storageBucket: 'bitpoint-app.appspot.com',
-        messagingSenderId: '889155584412'
+      apiKey: 'AIzaSyBetWWMHjfRV1xd91BFHkJ0-aZcsil956o',
+      authDomain: 'bitpoint-app.firebaseapp.com',
+      databaseURL: 'https://bitpoint-app.firebaseio.com',
+      projectId: 'bitpoint-app',
+      storageBucket: 'bitpoint-app.appspot.com',
+      messagingSenderId: '889155584412'
     }
 };

--- a/src/pages/login/login.ts
+++ b/src/pages/login/login.ts
@@ -37,7 +37,7 @@ export class LoginPage {
   }
 
   facebookLogin() {
-    console.log('chamar provider do facebook!');
+    this.authFacade.facebookAuth();
   }
 
   goToSignup() {

--- a/src/pages/login/state/login.effects.ts
+++ b/src/pages/login/state/login.effects.ts
@@ -13,6 +13,8 @@ import {
   AuthenticateAction,
   LoginAction,
   LoginFailAction,
+  FacebookAuthAction,
+  FacebookAuthFailAction,
 } from './../../../state';
 
 @Injectable()
@@ -22,7 +24,10 @@ export class LoginEffects extends BasePageEffects {
 
   // Show loading spinner every time LOGIN action is dispatched.
   @Effect({ dispatch: false }) signup$ = this.actions$
-    .ofType<LoginAction>(AuthActionTypes.LOGIN)
+    .ofType<LoginAction | FacebookAuthAction>(
+      AuthActionTypes.LOGIN,
+      AuthActionTypes.FACEBOOK_AUTH
+    )
     .do(_ => this.showLoading());
 
   // Every time AUTHENTICATE is successful:
@@ -40,7 +45,10 @@ export class LoginEffects extends BasePageEffects {
   // Dismiss loading spinner every time LOGIN FAIL action is dispatched.
   // Show alert every time LOGIN FAIL actions is dispatched.
   @Effect({ dispatch: false }) signupFail$ = this.actions$
-    .ofType<LoginFailAction>(AuthActionTypes.LOGIN_FAIL)
+    .ofType<LoginFailAction | FacebookAuthFailAction>(
+      AuthActionTypes.LOGIN_FAIL,
+      AuthActionTypes.FACEBOOK_AUTH_FAIL
+    )
     .map(action => action.payload)
     .do(error => {
       this.dismissLoading.next();

--- a/src/state/auth/auth.actions.ts
+++ b/src/state/auth/auth.actions.ts
@@ -3,13 +3,15 @@ import { Action } from '@ngrx/store';
 import { UserCredentials, FirebaseUserProfile } from './../../shared/models/auth';
 
 export enum AuthActionTypes {
-  SIGNUP          = '[Auth] Signup',
-  SIGNUP_FAIL     = '[Auth] Signup fail',
-  LOGIN           = '[Auth] Login',
-  LOGIN_FAIL      = '[Auth] Login fail',
-  AUTHENTICATE    = '[Auth] Authenticate user',
-  SIGNOUT         = '[Auth] Signout',
-  SIGNOUT_FAIL    = '[Auth] Signout fail',
+  SIGNUP              = '[Auth] Signup',
+  SIGNUP_FAIL         = '[Auth] Signup fail',
+  LOGIN               = '[Auth] Login',
+  LOGIN_FAIL          = '[Auth] Login fail',
+  FACEBOOK_AUTH       = '[Auth] Facebook auth',
+  FACEBOOK_AUTH_FAIL  = '[Auth] Facebook auth fail',
+  SIGNOUT             = '[Auth] Signout',
+  SIGNOUT_FAIL        = '[Auth] Signout fail',
+  AUTHENTICATE        = '[Auth] Authenticate user',
 }
 
 export class SignupAction implements Action {
@@ -27,18 +29,26 @@ export class LoginAction implements Action {
   constructor(public payload: UserCredentials) { }
 }
 
+export class LoginFailAction implements Action {
+  readonly type = AuthActionTypes.LOGIN_FAIL;
+  constructor(public payload: any) { }
+}
+
+export class FacebookAuthAction implements Action {
+  readonly type = AuthActionTypes.FACEBOOK_AUTH;
+}
+
+export class FacebookAuthFailAction implements Action {
+  readonly type = AuthActionTypes.FACEBOOK_AUTH_FAIL;
+  constructor(public payload: any) { }
+}
+
 export class SignoutAction implements Action {
   readonly type = AuthActionTypes.SIGNOUT;
-  constructor() { }
 }
 
 export class SignoutFailAction implements Action {
   readonly type = AuthActionTypes.SIGNOUT_FAIL;
-  constructor(public payload: any) { }
-}
-
-export class LoginFailAction implements Action {
-  readonly type = AuthActionTypes.LOGIN_FAIL;
   constructor(public payload: any) { }
 }
 
@@ -51,6 +61,8 @@ export type AuthActions = SignupAction
   | SignupFailAction
   | LoginAction
   | LoginFailAction
-  | AuthenticateAction
+  | FacebookAuthAction
+  | FacebookAuthFailAction
   | SignoutAction
-  | SignoutFailAction;
+  | SignoutFailAction
+  | AuthenticateAction;


### PR DESCRIPTION
Adds facebook authentication for easier user access. It uses facebook native on mobile devices to enhance user experience, but also falls back to web popup authentication method from firebase, in case of browsers.

Closes #40.